### PR TITLE
Fix(fe): Netlify 배포 후 https 에러 해결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
배포 후 아래 에러 해결
`xhr.js:251 Mixed Content: The page at 'https://coruscating-medovik-d52dbe.netlify.app/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://52.78.195.183:3003/api/expenses/summary?period=monthly&userId=Team2'. This request has been blocked; the content must be served over HTTPS.`